### PR TITLE
fix: setlocal nobuflisted to avoid Telescope cursor position errors

### DIFF
--- a/plugin/gptme.vim
+++ b/plugin/gptme.vim
@@ -113,6 +113,7 @@ function! s:gptme() range
     setlocal winfixheight
     setlocal nofoldenable
     setlocal bufhidden=hide
+    setlocal nobuflisted
 
     " Use appropriate terminal function based on Vim/Neovim
     if has('nvim')


### PR DESCRIPTION
I'm getting this error whenever I use `require('telescope.builtin').buffers` after having used gptme.nvim in the same session.

```
Error executing vim.schedule lua callback: ...share/nvim/lazy/telescope.nvim/lua/telescope/pickers.lua:1345: Cursor position outside buffe
r
stack traceback:
        [C]: in function 'nvim_win_set_cursor'
        ...share/nvim/lazy/telescope.nvim/lua/telescope/pickers.lua:1345: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

(This fix was ofc written with the help of gptme.)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `setlocal nobuflisted` to `s:gptme()` in `plugin/gptme.vim` to fix cursor position error with Telescope buffers.
> 
>   - **Behavior**:
>     - Adds `setlocal nobuflisted` to `s:gptme()` in `plugin/gptme.vim` to prevent buffer listing.
>     - Fixes cursor position error when using `require('telescope.builtin').buffers` after `gptme.nvim`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme.vim&utm_source=github&utm_medium=referral)<sup> for 199f1a8d42487e16dd6fe6407335fe8f76e912dd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->